### PR TITLE
[connect] - EINPROGRESS indicates nonblocking connection started

### DIFF
--- a/pico_bsd_sockets.c
+++ b/pico_bsd_sockets.c
@@ -331,7 +331,7 @@ int pico_connect(int sd, const struct sockaddr *_saddr, socklen_t socklen)
     }
 
     if (ep->nonblocking) {
-        pico_err = PICO_ERR_EAGAIN;
+        pico_err = PICO_ERR_EINPROGRESS;
         ep->error = pico_err;
     } else {
         /* wait for event */


### PR DESCRIPTION
`picotcp-bsd` currently indicates `EAGAIN` after a `connect()` for a nonblocking socket is initiated, which is not compatible with some posix libraries. It should instead indicate `EINPROGRESS`.

From `POSIX Programmer's Manual`:

```
EINPROGRESS
              O_NONBLOCK is set for the file descriptor for the socket and the connection cannot be immediately established;  the  connec‐
              tion shall be established asynchronously.
```

See https://github.com/tass-belgium/picotcp/pull/486 for the PR which adds the error code to picoTCP headers.